### PR TITLE
Improve MAVEN build Performance

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,7 @@
 		<cobertura-maven-plugin.version>2.5.2</cobertura-maven-plugin.version>
 		<maven-findbugs-plugin.version>2.5.2</maven-findbugs-plugin.version>
 		<maven-surefire-plugin.version>2.13</maven-surefire-plugin.version>
+		<closeTestReports>true</closeTestReports>
 	</properties>
 
 	<dependencies>
@@ -205,6 +206,7 @@
 				<artifactId>maven-surefire-plugin</artifactId>
 				<configuration>
 					<argLine>${sunfire.argLines}</argLine>
+					<disableXmlReport>${closeTestReports}</disableXmlReport>
 				</configuration>
 			</plugin>
 		</plugins>


### PR DESCRIPTION

That report generation takes time, slowing down the overall build. Reports are definitely useful, but do you need them every time you run the build. We can conditionally disable generating test reports by setting `<disableXmlReport>true<disableXmlReport>`. If you need to generate reports, just add `-DcloseTestReports=false` to the end of mvn build command.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
